### PR TITLE
fix llvm-sys version as 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 libc = "^0.2"
-llvm-sys = "=0.2.2"
+llvm-sys = ">=0.2.2"
 
 [build-dependencies]
 gcc = "0.3.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 
 [dependencies]
 libc = "*"
-llvm-sys = "*"
+llvm-sys = "0.2.2"
 
 [build-dependencies]
 gcc = "0.3.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ name = "llvm"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "*"
-llvm-sys = "0.2.2"
+libc = "^0.2"
+llvm-sys = "=0.2.2"
 
 [build-dependencies]
 gcc = "0.3.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ fn new_jit_ee(m: &Module, opt_lv: usize) -> Result<LLVMExecutionEngineRef, Strin
     let mut opts = new_mcjit_compiler_options(opt_lv);
     let opts_size = mem::size_of::<LLVMMCJITCompilerOptions>();
 
-    let ret = LLVMCreateMCJITCompilerForModule(&mut ee, m.0, &mut opts, opts_size as u64, &mut err);
+    let ret = LLVMCreateMCJITCompilerForModule(&mut ee, m.0, &mut opts, opts_size as usize, &mut err);
     llvm_ret!(ret, ee, err)
   }
 }


### PR DESCRIPTION
I found a build failure with llvm-sys 0.2.2 while working on Travis support.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hyunsik/llvm-rs/5)

<!-- Reviewable:end -->
